### PR TITLE
feat: add Accent config option for each color

### DIFF
--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -11,6 +11,7 @@
 
 @var select lightTheme "Light Variant" ["latte:Latte"]
 @var select darkTheme "Dark Variant" ["frappe:Frappe", "macchiato:Macchiato", "mocha:Mocha"]
+@var select accentColour  "Accent" ["rosewater:Rosewater", "flamingo:Flamingo", "pink:Pink", "mauve:Mauve", "red:Red*", "maroon:Maroon", "peach:Peach", "yellow:Yellow", "green:Green", "teal:Teal", "blue:Blue", "sapphire:Sapphire", "sky:Sky", "lavender:Lavender", "subtext0:Grey"]
 ==/UserStyle== */
 @-moz-document domain("twitch.tv") {
 
@@ -130,13 +131,13 @@
     }
 
     .tw-root--theme-dark {
-        #catppuccin(@darkTheme);
+        #catppuccin(@darkTheme, @accentColour);
     }
     .tw-root--theme-light {
-        #catppuccin(@lightTheme);
+        #catppuccin(@lightTheme, @accentColour);
     }
 
-    #catppuccin(@lookup) {
+    #catppuccin(@lookup, @accent) {
         @rosewater: @catppuccin[@@lookup][@rosewater];
         @flamingo: @catppuccin[@@lookup][@flamingo];
         @pink: @catppuccin[@@lookup][@pink];
@@ -163,6 +164,7 @@
         @base: @catppuccin[@@lookup][@base];
         @mantle: @catppuccin[@@lookup][@mantle];
         @crust: @catppuccin[@@lookup][@crust];
+        @accent-colour: @catppuccin[@@lookup][@@accent];
 
         & body {
             background-color: @base;
@@ -285,17 +287,17 @@
             --color-warn: @yellow;
             --color-success: @green;
             --color-info: @blue;
-            --color-accent: @mauve;
-            --color-twitch-purple: @mauve;
-            --color-twitch-purple-4: @mauve;
-            --color-twitch-purple-5: @mauve;
-            --color-twitch-purple-6: @mauve;
-            --color-twitch-purple-7: @mauve;
-            --color-twitch-purple-8: @mauve;
-            --color-twitch-purple-9: @mauve;
-            --color-twitch-purple-10: @mauve;
-            --color-twitch-purple-11: @mauve;
-            --color-twitch-purple-12: @mauve;
+            --color-accent: @accent-colour;
+            --color-twitch-purple: @accent-colour;
+            --color-twitch-purple-4: @accent-colour;
+            --color-twitch-purple-5: @accent-colour;
+            --color-twitch-purple-6: @accent-colour;
+            --color-twitch-purple-7: @accent-colour;
+            --color-twitch-purple-8: @accent-colour;
+            --color-twitch-purple-9: @accent-colour;
+            --color-twitch-purple-10: @accent-colour;
+            --color-twitch-purple-11: @accent-colour;
+            --color-twitch-purple-12: @accent-colour;
             --color-orange-7: @yellow;
             --color-orange-8: @yellow;
             --color-orange-9: @yellow;

--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -210,6 +210,9 @@
         .dDyYOA {
             color: #fff !important;
         }
+        .navigation-link__active-indicator {
+            background-color: @@accent !important;
+        }
         .footer {
             background: @crust;
         }

--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Twitch Catppuccin
 @namespace      github.com/catppuccin/twitch
 @homepageURL    https://github.com/catppuccin/twitch
-@version        1.0.8
+@version        1.0.9
 @description    Soothing pastel theme for Twitch
 @author         Catppuccin - mustafakhalaf-git
 @preprocessor   less


### PR DESCRIPTION
I saw the other styles (like for youtube) will ask what accent you want to use alongside the mocha,  Macchiato, etc.

Preview off suggested changed:
![image](https://user-images.githubusercontent.com/93456589/233891090-70d99eb0-42e4-4678-857b-334efa56e8d5.png)

Accent theme applied:
![image](https://user-images.githubusercontent.com/93456589/233891973-ed8b33c6-3ace-45a5-98df-44d1352d95b5.png)
