### PR TITLE
fix: buttons colour correction

### DIFF
--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Twitch Catppuccin
 @namespace      github.com/catppuccin/twitch
 @homepageURL    https://github.com/catppuccin/twitch
-@version        1.1.0
+@version        1.1.1
 @description    Soothing pastel theme for Twitch
 @author         Catppuccin - mustafakhalaf-git
 @preprocessor   less
@@ -193,7 +193,7 @@
             }
         }
         .bTJhJp {
-            color: #fff;
+            color: @crust;
         }
         .ffZeRf {
             color: #fff !important;
@@ -239,7 +239,7 @@
         &,
         .side-nav-card__link:hover {
             --color-background-input-focus: @crust --color-background-interactable-hover: @surface0;
-            --color-background-button-text-default: @crust;
+            --color-background-button-text-default: null !important;
             --color-background-float: @crust;
             --color-text-input-placeholder: @text;
             --color-border-input: @base;


### PR DESCRIPTION
fix to make the buttons colours more inline with twitch (further testing maybe needed)

Example 1:
original:
![image](https://github.com/catppuccin/twitch/assets/71222764/327ddbed-3254-4363-8726-88214833e194)
before change: 
![image](https://github.com/catppuccin/twitch/assets/71222764/9406d045-f991-4920-a4a1-3274f2e0f5c4)
after change:
![image](https://github.com/catppuccin/twitch/assets/71222764/a88c2717-8838-42fa-9430-5e4ccb9b338b)

Example 2:
original:
![image](https://github.com/catppuccin/twitch/assets/71222764/1cf27290-0bbf-4f5a-99e9-af5384579aca)
before change:
![image](https://github.com/catppuccin/twitch/assets/71222764/e18d743f-5414-4f89-ad34-235c004b7ed6)
after change:
![image](https://github.com/catppuccin/twitch/assets/71222764/1241541e-68e1-4cf4-ad13-8ba7e23c26cd)
