### PR TITLE
feat: use mantle for logo

### DIFF
--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Twitch Catppuccin
 @namespace      github.com/catppuccin/twitch
 @homepageURL    https://github.com/catppuccin/twitch
-@version        1.1.0
+@version        1.1.1
 @description    Soothing pastel theme for Twitch
 @author         Catppuccin - mustafakhalaf-git
 @preprocessor   less
@@ -182,6 +182,9 @@
         }
         .jmUA-dj {
             background-color: @mantle;
+        }
+        .bBpiku {
+            fill: @mantle;
         }
         .gzYMLv {
             color: @text;


### PR DESCRIPTION
With the suggested change, the logo becomes easier to see as the ctp accent colours are lighter therefore I think it looks better this way.
Original:
![image](https://github.com/catppuccin/twitch/assets/71222764/0a281fb1-52ba-4ff8-aebc-672acc80c545)
Change:
![image](https://github.com/catppuccin/twitch/assets/71222764/d3c8b4e9-3f1a-47f6-ace4-a59eb63ee047)
