### PR TITLE
fix: highlighted message follows accent colour

### DIFF
--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name           Twitch Catppuccin
 @namespace      github.com/catppuccin/twitch
 @homepageURL    https://github.com/catppuccin/twitch
-@version        1.1.0
+@version        1.1.1
 @description    Soothing pastel theme for Twitch
 @author         Catppuccin - mustafakhalaf-git
 @preprocessor   less
@@ -176,7 +176,11 @@
         & .carousel-metadata--fadeout {
             background: @crust;
         }
-
+        .chat-line__message-body--highlighted {
+            background-color: @accent-colour;
+            color: @crust;
+            border-color: @accent-colour;
+        }
         .chat-scrollable-area__message-container {
             background-color: @mantle;
         }


### PR DESCRIPTION
(not the best example but best I could get)
before change:
![image](https://github.com/catppuccin/twitch/assets/71222764/f9cb4ce9-1dd9-4d62-929d-e5990d274ada)
after change:
![image](https://github.com/catppuccin/twitch/assets/71222764/1333e67a-4028-430b-a267-c385a8996aa4)
